### PR TITLE
WAF-79 | fixing terraform 0.14 compatible provider plugins init

### DIFF
--- a/modules/github-membership/versions.tf
+++ b/modules/github-membership/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     github = "~> 3.0.0"

--- a/modules/github-repository/versions.tf
+++ b/modules/github-repository/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     github = "~> 3.0.0"

--- a/modules/github-team-repository/versions.tf
+++ b/modules/github-team-repository/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     github = "~> 3.0.0"

--- a/modules/github-team/versions.tf
+++ b/modules/github-team/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     github = "~> 3.0.0"


### PR DESCRIPTION
## What?
### Commits on Jan 04, 2021
- @exequielrafaela - WAF-79 | fixing terraform 0.14 compatible provider plugins init - 24c3f18

## Why?
- https://flexibility.atlassian.net/browse/WAF-92